### PR TITLE
fix reserved characters encoded twice

### DIFF
--- a/src/native-http-backend.spec.ts
+++ b/src/native-http-backend.spec.ts
@@ -351,4 +351,29 @@ describe('NativeHttpBackend', () => {
             done();
         });
     });
+
+    it('should not encode already encoded URL which includes reserved characters', done => {
+        const request = new HttpRequest(
+            'POST',
+            'http://api.com/test?reserved=%3B%2C%2F%3F%3A%40%26%3D%2B%24%23',
+            'a=b&c=d',
+        );
+
+        spyOn(http, 'post').and.returnValue(
+            Promise.resolve({
+                status: 200,
+                data: '{}',
+                headers: {},
+            }),
+        );
+
+        httpBackend.handle(request).subscribe(() => {
+            expect(http.post).toHaveBeenCalledWith(
+                'http://api.com/test?reserved=%3B%2C%2F%3F%3A%40%26%3D%2B%24%23',
+                expect.anything(),
+                expect.anything(),
+            );
+            done();
+        });
+    });
 });

--- a/src/native-http-backend.ts
+++ b/src/native-http-backend.ts
@@ -68,8 +68,8 @@ export class NativeHttpBackend implements HttpBackend {
              * converts not encoded URL, NativeHTTP requires it to be always encoded.
              */
             const url = encodeURI(decodeURI(req.urlWithParams)).replace(
-                '%252F',
-                '%2F',
+                /%253B|%252C|%252F|%253F|%253A|%2540|%2526|%253D|%252B|%2524|%2523/g, // ;,/?:@&=+$#
+                substring => '%' + substring.slice(3),
             );
 
             const fireResponse = (response: {


### PR DESCRIPTION
In NativeHttpBackend, url passed to native plugin is calculated as follows 

```
url  = encodeURI(decodeURI(req.urlWithParams)).replace('%252F', '%2F')
```

However, if `req.urlWithParams` contains some [reserved characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI#Description) other than `/`,
reserved character is **not encoded** or **encoded twice**.

example:
- `+` -- decodeURI --> `+` -- encodeURI --> `+`
- `%2B` -- decodeURI --> `%2B` -- encodeURI --> `%252B`

This PR should fix this issue.
