### PR TITLE
Feature: serialize http-params body

### DIFF
--- a/src/native-http-backend.spec.ts
+++ b/src/native-http-backend.spec.ts
@@ -162,6 +162,71 @@ describe('NativeHttpBackend', () => {
         });
     });
 
+    it('loves and understands http-params as body', done => {
+        const httpParamBody = new HttpParams().set('a', '1').set('b', '2');
+        const request = new HttpRequest(
+            'POST',
+            'http://test.com',
+            httpParamBody,
+        );
+
+        spyOn(http, 'post').and.returnValue(
+            Promise.resolve({
+                status: 200,
+                data: '{}',
+                headers: {},
+            }),
+        );
+
+        spyOn(http, 'setDataSerializer');
+
+        httpBackend.handle(request).subscribe(() => {
+            expect(http.setDataSerializer).toHaveBeenCalledWith('json');
+            expect(http.post).toHaveBeenCalledWith(
+                expect.anything(),
+                { a: '1', b: '2' },
+                expect.anything(),
+            );
+            done();
+        });
+    });
+
+    it('uses urlencoded serialization for corresponding content type and http-param body', done => {
+        const httpParamBody = new HttpParams()
+            .append('a', '1')
+            .append('b', '2');
+        const request = new HttpRequest(
+            'POST',
+            'http://test.com',
+            httpParamBody,
+            {
+                headers: new HttpHeaders({
+                    'Content-Type': ['application/x-www-form-urlencoded'],
+                }),
+            },
+        );
+
+        spyOn(http, 'post').and.returnValue(
+            Promise.resolve({
+                status: 200,
+                data: '{}',
+                headers: {},
+            }),
+        );
+
+        spyOn(http, 'setDataSerializer');
+
+        httpBackend.handle(request).subscribe(() => {
+            expect(http.setDataSerializer).toHaveBeenCalledWith('urlencoded');
+            expect(http.post).toHaveBeenCalledWith(
+                expect.anything(),
+                { a: '1', b: '2' },
+                expect.anything(),
+            );
+            done();
+        });
+    });
+
     it('converts HTTPResponse headers object to Headers', done => {
         const request = new HttpRequest('POST', 'http://test.com', 'a=b&c=d');
 

--- a/src/native-http-backend.ts
+++ b/src/native-http-backend.ts
@@ -5,6 +5,7 @@ import {
     HttpHeaders,
     HttpRequest,
     HttpResponse,
+    HttpParams,
 } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { HTTP, HTTPResponse } from '@ionic-native/http/ngx';
@@ -58,6 +59,12 @@ export class NativeHttpBackend implements HttpBackend {
                 body = this.getBodyParams(req.body);
             } else if (Array.isArray(req.body)) {
                 body = req.body;
+            } else if (req.body instanceof HttpParams) {
+                let result = {};
+                for (let key of req.body.keys()) {
+                    result[key] = req.body.get(key);
+                }
+                body = result;
             } else {
                 body = { ...req.body };
             }
@@ -173,6 +180,10 @@ export class NativeHttpBackend implements HttpBackend {
 
         if (reqContentType.indexOf('application/json') === 0) {
             return 'json';
+        }
+
+        if (reqContentType.indexOf('application/x-www-form-urlencoded') === 0) {
+            return 'urlencoded';
         }
 
         return null;


### PR DESCRIPTION
The regular HttpClient accepts HttpParam as body parameter.
To improve the compatibility of the native http-client with the regular http-client we added this functionality.
Currently the implementation only enables us to use unique-key parameters, not multi-key parameters, e.g. array parameters.

Additionally the urlencoded serialization was only available for plain strings.
We needed this for HttpParams also.
So we added the respective case to the serialization detection using the corresponding header.