### PR TITLE
feat(native-http-backend): send JSON primitives

### DIFF
--- a/src/utils/body-to-utf8.ts
+++ b/src/utils/body-to-utf8.ts
@@ -1,0 +1,9 @@
+import { HttpParams } from '@angular/common/http';
+
+export const bodyToUtf8 = (body: any): string => {
+    if (body instanceof HttpParams) {
+        return body.toString();
+    }
+
+    return JSON.stringify(body);
+};

--- a/src/utils/create-headers.spec.ts
+++ b/src/utils/create-headers.spec.ts
@@ -1,0 +1,67 @@
+import { buildHeaders, createHeaders } from './create-headers';
+import { HttpHeaders, HttpRequest } from '@angular/common/http';
+
+describe('createHeaders', () => {
+    it('should use existing content type', () => {
+        expect(
+            createHeaders(
+                new HttpRequest<any>(
+                    'POST',
+                    'http://something.com?a=b',
+                    'Json Primitive',
+                    {
+                        headers: new HttpHeaders({
+                            'CoNtEnt-TyPe': 'application/json',
+                        }),
+                    },
+                ),
+            ),
+        ).toEqual({
+            'CoNtEnt-TyPe': 'application/json',
+        });
+    });
+
+    it('should use detected content type', () => {
+        expect(
+            createHeaders(
+                new HttpRequest<any>(
+                    'POST',
+                    'http://something.com?a=b',
+                    'Json Primitive',
+                ),
+            ),
+        ).toEqual({
+            'Content-Type': 'text/plain',
+        });
+    });
+
+    it('should not assign content type when it can not be detected', () => {
+        expect(
+            createHeaders(
+                new HttpRequest<any>(
+                    'POST',
+                    'http://something.com?a=b',
+                    new FormData(),
+                ),
+            ),
+        ).toEqual({});
+    });
+});
+
+describe('buildHeaders', () => {
+    it('should build a headers object', () => {
+        expect(
+            buildHeaders(
+                new HttpHeaders({
+                    a: ['a1', 'a2'],
+                    b: ['b1'],
+                    c: 'c1',
+                }),
+            ),
+        ).toEqual({
+            a: 'a1,a2',
+            b: 'b1',
+            c: 'c1',
+        });
+    });
+});

--- a/src/utils/create-headers.ts
+++ b/src/utils/create-headers.ts
@@ -1,0 +1,25 @@
+import { HttpHeaders, HttpRequest } from '@angular/common/http';
+
+type Headers = Record<string, string>;
+
+export const buildHeaders = (headers: HttpHeaders): Headers => {
+    return headers.keys().reduce((headersObject, key) => {
+        return {
+            ...headersObject,
+            [key]: headers.getAll(key).join(','),
+        };
+    }, {});
+};
+
+export const createHeaders = (req: HttpRequest<any>): Headers => {
+    let headers = req.headers;
+
+    if (!req.headers.has('Content-Type')) {
+        const detectedContentType = req.detectContentTypeHeader();
+        if (detectedContentType) {
+            headers = headers.append('Content-Type', detectedContentType);
+        }
+    }
+
+    return buildHeaders(headers);
+};

--- a/src/utils/detect-serializer-and-data.spec.ts
+++ b/src/utils/detect-serializer-and-data.spec.ts
@@ -1,0 +1,154 @@
+import { detectSerializerAndData } from './detect-serializer-and-data';
+import { HttpHeaders, HttpParams, HttpRequest } from '@angular/common/http';
+
+describe('detectSerializerAndData', () => {
+    it('should should skip data and use urlencoded serializer for non-data requests', () => {
+        expect(
+            detectSerializerAndData(
+                new HttpRequest<any>('GET', 'http://something.com?a=b'),
+            ),
+        ).toStrictEqual({
+            serializer: 'urlencoded',
+        });
+    });
+
+    test('serializer: utf8, data as is, on "text/plain"', () => {
+        expect(
+            detectSerializerAndData(
+                new HttpRequest<any>(
+                    'POST',
+                    'http://something.com',
+                    'Free form text',
+                    {
+                        headers: new HttpHeaders({
+                            'content-type': 'text/plain',
+                        }),
+                    },
+                ),
+            ),
+        ).toStrictEqual({
+            serializer: 'utf8',
+            data: 'Free form text',
+        });
+    });
+
+    test('serializer: utf8, data json string. On "application/json", body is a primitive', () => {
+        expect(
+            detectSerializerAndData(
+                new HttpRequest<any>(
+                    'POST',
+                    'http://something.com',
+                    'Free form text',
+                    {
+                        headers: new HttpHeaders({
+                            'content-type': 'application/json',
+                        }),
+                    },
+                ),
+            ),
+        ).toStrictEqual({
+            serializer: 'utf8',
+            data: JSON.stringify('Free form text'),
+        });
+    });
+
+    test('serializer: utf8, data json string. On "application/json", body is an object', () => {
+        expect(
+            detectSerializerAndData(
+                new HttpRequest<any>(
+                    'POST',
+                    'http://something.com',
+                    { a: 'b' },
+                    {
+                        headers: new HttpHeaders({
+                            'content-type': 'application/json',
+                        }),
+                    },
+                ),
+            ),
+        ).toStrictEqual({
+            serializer: 'utf8',
+            data: JSON.stringify({ a: 'b' }),
+        });
+    });
+
+    test('serializer: utf8, data json string. On "application/json", body is HttpParams', () => {
+        expect(
+            detectSerializerAndData(
+                new HttpRequest<any>(
+                    'POST',
+                    'http://something.com',
+                    new HttpParams({
+                        fromObject: { a: 'b', c: 'd' },
+                    }),
+                    {
+                        headers: new HttpHeaders({
+                            'content-type': 'application/json',
+                        }),
+                    },
+                ),
+            ),
+        ).toStrictEqual({
+            serializer: 'utf8',
+            data: new HttpParams({
+                fromObject: { a: 'b', c: 'd' },
+            }).toString(),
+        });
+    });
+
+    test('serializer: multipart, body FormData. On unknown content type, body is HttpParams', () => {
+        const expectedData = new FormData();
+        expectedData.append('a', 'b');
+        expectedData.append('c', 'd');
+
+        expect(
+            detectSerializerAndData(
+                new HttpRequest<any>(
+                    'POST',
+                    'http://something.com',
+                    new HttpParams({
+                        fromObject: { a: 'b', c: 'd' },
+                    }),
+                ),
+            ),
+        ).toStrictEqual({
+            serializer: 'multipart',
+            data: expectedData,
+        });
+    });
+
+    test('serializer: multipart, body FormData. On unknown header, body is FormData', () => {
+        const formData = new FormData();
+        formData.append('a', 'b');
+        formData.append('c', 'd');
+
+        expect(
+            detectSerializerAndData(
+                new HttpRequest<any>('POST', 'http://something.com', formData),
+            ),
+        ).toStrictEqual({
+            serializer: 'multipart',
+            data: formData,
+        });
+    });
+
+    test('serializer: urlencoded, body object. On anything else', () => {
+        expect(
+            detectSerializerAndData(
+                new HttpRequest<any>(
+                    'POST',
+                    'http://something.com',
+                    'a=b&c=d',
+                    {
+                        headers: new HttpHeaders({
+                            'content-type': 'application/x-www-form-urlencoded',
+                        }),
+                    },
+                ),
+            ),
+        ).toStrictEqual({
+            serializer: 'urlencoded',
+            data: { a: 'b', c: 'd' },
+        });
+    });
+});

--- a/src/utils/detect-serializer-and-data.ts
+++ b/src/utils/detect-serializer-and-data.ts
@@ -1,0 +1,56 @@
+import { HttpParams, HttpRequest } from '@angular/common/http';
+import { RequestOptions } from './types';
+import { bodyToObject } from './http-params';
+import { httpParamsToFormData } from './http-params-to-form-data';
+import { bodyToUtf8 } from './body-to-utf8';
+
+const DATA_REQUEST_METHODS = ['post', 'put', 'patch'];
+
+export const detectSerializerAndData = (
+    req: HttpRequest<any>,
+): Partial<RequestOptions> => {
+    if (!DATA_REQUEST_METHODS.includes(req.method.toLowerCase())) {
+        return {
+            serializer: 'urlencoded',
+        };
+    }
+
+    const contentType =
+        req.headers.get('Content-Type') ?? req.detectContentTypeHeader() ?? '';
+
+    if (contentType.indexOf('text/') === 0) {
+        return {
+            serializer: 'utf8',
+            data: req.body,
+        };
+    }
+
+    if (contentType.indexOf('application/json') === 0) {
+        return {
+            serializer: 'utf8',
+            data: bodyToUtf8(req.body),
+        };
+    }
+
+    if (
+        contentType.indexOf('application/x-www-form-urlencoded') === 0 &&
+        req.body instanceof HttpParams
+    ) {
+        return {
+            serializer: 'multipart',
+            data: httpParamsToFormData(req.body),
+        };
+    }
+
+    if (req.body instanceof FormData) {
+        return {
+            serializer: 'multipart',
+            data: req.body,
+        };
+    }
+
+    return {
+        serializer: 'urlencoded',
+        data: bodyToObject(req.body),
+    };
+};

--- a/src/utils/http-params-to-form-data.spec.ts
+++ b/src/utils/http-params-to-form-data.spec.ts
@@ -1,0 +1,18 @@
+import { httpParamsToFormData } from './http-params-to-form-data';
+import { HttpParams } from '@angular/common/http';
+
+describe('httpParamsToFormData', () => {
+    it('should respect a single param', () => {
+        const httpParams = new HttpParams().append('a', '1');
+        const formData = httpParamsToFormData(httpParams);
+
+        expect(formData.getAll('a')).toEqual(['1']);
+    });
+
+    it('should respect multiple params', () => {
+        const httpParams = new HttpParams().append('a', '1').append('a', '2');
+        const formData = httpParamsToFormData(httpParams);
+
+        expect(formData.getAll('a')).toEqual(['1', '2']);
+    });
+});

--- a/src/utils/http-params-to-form-data.ts
+++ b/src/utils/http-params-to-form-data.ts
@@ -1,0 +1,13 @@
+import { HttpParams } from '@angular/common/http';
+
+export const httpParamsToFormData = (params: HttpParams): FormData => {
+    const formData = new FormData();
+
+    params.keys().forEach((key) => {
+        params.getAll(key).forEach((value) => {
+            formData.append(key, value);
+        });
+    });
+
+    return formData;
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,7 @@
+import { HTTP } from '@ionic-native/http/ngx';
+
+export type RequestOptions =
+    | Parameters<typeof HTTP.prototype.sendRequest>[1]
+    | {
+          data?: Object | FormData | string;
+      };


### PR DESCRIPTION
The original purpose of the change is to send JSON primitives with application/json requests. The
feature had required a rework of serializer and data detection. As a result, the commit is also
fixing a number of bugs such as supporting application/x-www-form-urlencoded requests, sending HttpParams object, and multiple values in headers.

re #111, fix #103, fix #101, re #64, fix #31