### PR TITLE
fix: respect non-composite http params

### DIFF
--- a/src/utils/detect-serializer-and-data.spec.ts
+++ b/src/utils/detect-serializer-and-data.spec.ts
@@ -169,7 +169,8 @@ describe('detectSerializerAndData', () => {
                     'Free form text',
                     {
                         headers: new HttpHeaders({
-                            'content-type': 'application/vnd+company.category+json',
+                            'content-type':
+                                'application/vnd+company.category+json',
                         }),
                     },
                 ),
@@ -189,7 +190,8 @@ describe('detectSerializerAndData', () => {
                     { a: 'b' },
                     {
                         headers: new HttpHeaders({
-                            'content-type': 'application/vnd+company.category+json',
+                            'content-type':
+                                'application/vnd+company.category+json',
                         }),
                     },
                 ),
@@ -211,7 +213,8 @@ describe('detectSerializerAndData', () => {
                     }),
                     {
                         headers: new HttpHeaders({
-                            'content-type': 'application/vnd+company.category+json',
+                            'content-type':
+                                'application/vnd+company.category+json',
                         }),
                     },
                 ),
@@ -233,7 +236,8 @@ describe('detectSerializerAndData', () => {
                     'Free form text',
                     {
                         headers: new HttpHeaders({
-                            'content-type': 'application/vnd+company.category+json; charset=utf-8',
+                            'content-type':
+                                'application/vnd+company.category+json; charset=utf-8',
                         }),
                     },
                 ),
@@ -253,7 +257,8 @@ describe('detectSerializerAndData', () => {
                     { a: 'b' },
                     {
                         headers: new HttpHeaders({
-                            'content-type': 'application/vnd+company.category+json; charset=utf-8',
+                            'content-type':
+                                'application/vnd+company.category+json; charset=utf-8',
                         }),
                     },
                 ),
@@ -275,7 +280,8 @@ describe('detectSerializerAndData', () => {
                     }),
                     {
                         headers: new HttpHeaders({
-                            'content-type': 'application/vnd+company.category+json; charset=utf-8',
+                            'content-type':
+                                'application/vnd+company.category+json; charset=utf-8',
                         }),
                     },
                 ),
@@ -288,7 +294,7 @@ describe('detectSerializerAndData', () => {
         });
     });
 
-    test('serializer: multipart, body FormData. On unknown content type, body is HttpParams', () => {
+    test('serializer: multipart, body FormData. On unknown content type, body is non-composite HttpParams', () => {
         const expectedData = new FormData();
         expectedData.append('a', 'b');
         expectedData.append('c', 'd');
@@ -300,6 +306,27 @@ describe('detectSerializerAndData', () => {
                     'http://something.com',
                     new HttpParams({
                         fromObject: { a: 'b', c: 'd' },
+                    }),
+                ),
+            ),
+        ).toStrictEqual({
+            serializer: 'urlencoded',
+            data: { a: 'b', c: 'd' },
+        });
+    });
+
+    test('serializer: multipart, body FormData. On unknown content type, body is composite HttpParams', () => {
+        const expectedData = new FormData();
+        expectedData.append('a', 'b');
+        expectedData.append('a', 'd');
+
+        expect(
+            detectSerializerAndData(
+                new HttpRequest<any>(
+                    'POST',
+                    'http://something.com',
+                    new HttpParams({
+                        fromObject: { a: ['b', 'd'] },
                     }),
                 ),
             ),

--- a/src/utils/detect-serializer-and-data.ts
+++ b/src/utils/detect-serializer-and-data.ts
@@ -3,6 +3,7 @@ import { RequestOptions } from './types';
 import { bodyToObject } from './http-params';
 import { httpParamsToFormData } from './http-params-to-form-data';
 import { bodyToUtf8 } from './body-to-utf8';
+import { isCompositeHttpParams } from './is-composite-http-params';
 
 const DATA_REQUEST_METHODS = ['post', 'put', 'patch'];
 
@@ -34,7 +35,8 @@ export const detectSerializerAndData = (
 
     if (
         contentType.indexOf('application/x-www-form-urlencoded') === 0 &&
-        req.body instanceof HttpParams
+        req.body instanceof HttpParams &&
+        isCompositeHttpParams(req.body)
     ) {
         return {
             serializer: 'multipart',

--- a/src/utils/is-composite-http-params.spec.ts
+++ b/src/utils/is-composite-http-params.spec.ts
@@ -1,0 +1,24 @@
+import { HttpParams } from '@angular/common/http';
+import { isCompositeHttpParams } from './is-composite-http-params';
+
+describe('isCompositeHttpParams', () => {
+    it('return false for non-composite params', () => {
+        expect(isCompositeHttpParams(new HttpParams())).toBeFalsy();
+        expect(
+            isCompositeHttpParams(new HttpParams().set('a', 'b').set('b', 'c')),
+        ).toBeFalsy();
+    });
+
+    it('should return true for composite params', () => {
+        expect(
+            isCompositeHttpParams(
+                new HttpParams()
+                    .set('client_id', 'my-client-id')
+                    .set('username', 'my-username')
+                    .set('password', 'my-password')
+                    .set('a', 'b')
+                    .append('a', 'c'),
+            ),
+        ).toBeTruthy();
+    });
+});

--- a/src/utils/is-composite-http-params.ts
+++ b/src/utils/is-composite-http-params.ts
@@ -1,0 +1,4 @@
+import { HttpParams } from '@angular/common/http';
+
+export const isCompositeHttpParams = (params: HttpParams): boolean =>
+    params.keys().some((key) => params.getAll(key).length > 1);


### PR DESCRIPTION
Use urlencoded serializer on application/x-www-form-urlencoded content type and non-composite HttpParams

fix #154, fix #137
