### PR TITLE
build(deps): bump awesome-cordova-plugins to 6.0.1

### DIFF
--- a/jest.init.ts
+++ b/jest.init.ts
@@ -1,2 +1,3 @@
 import 'zone.js';
 import 'core-js/proposals/reflect-metadata';
+import '@angular/compiler';

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,18 +81,18 @@
       }
     },
     "@awesome-cordova-plugins/core": {
-      "version": "5.37.3",
-      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/core/-/core-5.37.3.tgz",
-      "integrity": "sha512-CKFV7WQVqSdcHbmZgXHby96i0jkmy4wsEOpP/WZIAWcDAKmBy9M/mPn25vVHbgPlEj2filcfagzInm3dApn4/g==",
+      "version": "6.0.1",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/gb60-npm/@awesome-cordova-plugins/core/-/core-6.0.1.tgz",
+      "integrity": "sha512-DTlyvVrqwRG7fwhmc2Nu514ACiSX7AkwG8lCoJqgnav6md+hABqZ+pJNpfmMtuQEzhoev/Mh+aZ2LdG3d065ow==",
       "dev": true,
       "requires": {
         "@types/cordova": "^0.0.34"
       }
     },
     "@awesome-cordova-plugins/http": {
-      "version": "5.37.3",
-      "resolved": "https://registry.npmjs.org/@awesome-cordova-plugins/http/-/http-5.37.3.tgz",
-      "integrity": "sha512-rBugr4ZG2ugPEZyGp0Ujq9DP2K0IOStYXTCN/U/C1E+w7PUDtobXr1BBmJOapf9dcLjwivKpz94gdzJt0f8zmg==",
+      "version": "6.0.1",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/gb60-npm/@awesome-cordova-plugins/http/-/http-6.0.1.tgz",
+      "integrity": "sha512-jOYRgPopVTdRAR77HQGO6jZVK+uUBqWlBV9X0AwU8389BLC0lliMDU4XlwCQVpoYDAxAT/PB6nCZRTZ3KAj+2g==",
       "dev": true,
       "requires": {
         "@types/cordova": "^0.0.34"
@@ -1782,8 +1782,8 @@
     },
     "@types/cordova": {
       "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@types/cordova/-/cordova-0.0.34.tgz",
-      "integrity": "sha1-6nrd907Ow9dimCegw54smt3HPQQ=",
+      "resolved": "https://repo.inform-software.com/artifactory/api/npm/gb60-npm/@types/cordova/-/cordova-0.0.34.tgz",
+      "integrity": "sha512-rkiiTuf/z2wTd4RxFOb+clE7PF4AEJU0hsczbUdkHHBtkUmpWQpEddynNfJYKYtZFJKbq4F+brfekt1kx85IZA==",
       "dev": true
     },
     "@types/graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "@angular/router": "^12.0.1",
     "@commitlint/cli": "^12.1.4",
     "@commitlint/config-conventional": "^12.1.4",
-    "@awesome-cordova-plugins/core": "^5.37.3",
-    "@awesome-cordova-plugins/http": "^5.37.3",
+    "@awesome-cordova-plugins/core": "^6.0.1",
+    "@awesome-cordova-plugins/http": "^6.0.1",
     "@ionic/angular": "^5.6.7",
     "@ionic/core": "^5.6.7",
     "@semantic-release/git": "^9.0.0",
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "@angular/core": ">=12.0.1",
-    "@awesome-cordova-plugins/http": "^5.36.0"
+    "@awesome-cordova-plugins/http": "^6.0.1"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
This updates the awesome-cordova-plugins dependency to the new major verison, which now directly supports angular ivy and uses partial compilation mode.

I think this is technically a breaking change, as the peerDependency requirements change and the angular app this library must have ivy enabled.